### PR TITLE
refactor(error): introduce dedicated errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,12 +90,12 @@ dependencies = [
 name = "dbo_csv"
 version = "0.1.0-alpha.0"
 dependencies = [
- "anyhow",
  "chrono",
  "csv",
  "encoding_rs",
  "encoding_rs_rw",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -260,6 +254,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 license-file = "LICENSE"
 
 [dependencies]
-anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 csv = "1.3"
 encoding_rs = "0.8.33"
 encoding_rs_rw = "0.4.2"
 serde = { version = "1", features = ["derive"]}
+thiserror = "2"

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -32,7 +32,7 @@ where
             Ok(record) => records.push(record),
             Err(err) => {
                 return Err(DboCsvError::InvalidRecord {
-                    row_number: idx,
+                    row_number: idx + 2, // the DBO files have headers and numbering starts with 1
                     message: err.to_string(),
                 });
             }

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -3,13 +3,19 @@
 //! The format is used by the popular online bank.
 use std::io::{BufReader, Read};
 
-use anyhow::bail;
 use encoding_rs::WINDOWS_1251;
 use encoding_rs_rw::DecodingReader;
+use thiserror::Error;
 
 use crate::record::{DboRecord, DboStatement};
 
-pub fn deserialize_statement<R>(reader: R) -> anyhow::Result<DboStatement>
+#[derive(Debug, Error)]
+pub enum DboCsvError {
+    #[error("failed to deserialize row {row_number} in the statement. the issue is {message}")]
+    InvalidRecord { row_number: usize, message: String },
+}
+
+pub fn deserialize_statement<R>(reader: R) -> Result<DboStatement, DboCsvError>
 where
     R: Read,
 {
@@ -21,10 +27,15 @@ where
         .from_reader(&mut reader);
     let record_iter = csv_reader.deserialize::<DboRecord>().skip(1);
     let mut records = vec![];
-    for r in record_iter {
+    for (idx, r) in record_iter.enumerate() {
         match r {
             Ok(record) => records.push(record),
-            Err(err) => bail!(err),
+            Err(err) => {
+                return Err(DboCsvError::InvalidRecord {
+                    row_number: idx,
+                    message: err.to_string(),
+                });
+            }
         }
     }
     Ok(DboStatement::new(records))


### PR DESCRIPTION
It's more common for libraries to use thiserror crate with dedicated
error types instead of generalising errors with anyhow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling for CSV deserialization with detailed error messages including row numbers and specific descriptions.

* **Chores**
  * Updated project dependencies by replacing the generic error handling library with a more descriptive error reporting library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->